### PR TITLE
[AD-366] update FBSDKCoreKit version

### DIFF
--- a/ios/flutter_facebook_app_links.podspec
+++ b/ios/flutter_facebook_app_links.podspec
@@ -15,7 +15,7 @@ Flutter plugin for Facebook App Links SDK
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 17.4.0'
+  s.dependency 'FBSDKCoreKit', '~> 18.0.0'
   s.swift_version       = '4.0'
 
   s.ios.deployment_target = '11.0'


### PR DESCRIPTION
https://github.com/facebook/facebook-android-sdk/issues/1345
위의 이슈로 인해 flutter 에서 의존하는 패키지 버전을 상향하면 ios 에서 facebook sdk 버전 호환성 문제가 발생합니다.

이를 해결하기 위해, 해당 프로젝트가 의존하는 FBSDKCoreKit 의 버전을 상향합니다.